### PR TITLE
Make jenkins use default storage class without specifying its name

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/home-pvc.yaml
+++ b/charts/ks-devops/charts/jenkins/templates/home-pvc.yaml
@@ -20,7 +20,6 @@ spec:
       storage: {{ .Values.Persistence.Size | quote }}
 {{- if .Values.Persistence.StorageClass }}
 {{- if (eq "-" .Values.Persistence.StorageClass) }}
-  storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.Persistence.StorageClass }}"
 {{- end }}

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -403,7 +403,7 @@ Agent:
 
 Persistence:
   Enabled: true
-  StorageClass: "local"
+  StorageClass: "-"
 #  ExistingClaim: ""
 
   Annotations: {}


### PR DESCRIPTION
Signed-off-by: johnniang <johnniang@fastmail.com>

This pull request is trying to make jenkins use default storage class without specifying its name . For any context details please have a look at the issue below.

Fix #10 