### PR TITLE
Add s2i dependency into ks-devops chart

### DIFF
--- a/charts/ks-devops/Chart.yaml
+++ b/charts/ks-devops/Chart.yaml
@@ -25,4 +25,5 @@ appVersion: 1.16.0
 dependencies:
   - name: jenkins
     version: 0.19.0
-    repository: file://jenkins
+  - name: s2i
+    version: 1.16.0


### PR DESCRIPTION
Signed-off-by: johnniang <johnniang@fastmail.com>

Adding missing s2i dependency into ks-devops chart fixes dependencies error while executing `helm lint`.