### PR TITLE
Fix nil error while token is empty

### DIFF
--- a/pkg/client/k8s/kubernetes.go
+++ b/pkg/client/k8s/kubernetes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package k8s
 
 import (
+	"errors"
 	"strings"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -110,17 +111,16 @@ func NewKubernetesClientWithConfig(config *rest.Config) (client Client, err erro
 // NewKubernetesClientWithToken creates a k8s client with a bearer token
 func NewKubernetesClientWithToken(token string, master string) (client Client, err error) {
 	if token == "" {
-		return
+		return nil, errors.New("token required")
 	}
 
-	client, err = NewKubernetesClientWithConfig(&rest.Config{
+	return NewKubernetesClientWithConfig(&rest.Config{
 		BearerToken: token,
 		Host:        master,
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: true,
 		},
 	})
-	return
 }
 
 // NewKubernetesClient creates a KubernetesClient

--- a/pkg/client/k8s/kubernetes_test.go
+++ b/pkg/client/k8s/kubernetes_test.go
@@ -50,7 +50,7 @@ func TestNewKubernetesClientWithToken(t *testing.T) {
 		name:       "nil arg",
 		args:       args{},
 		wantClient: nil,
-		wantErr:    false,
+		wantErr:    true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -23,11 +23,9 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/constants"
-	"net/http"
-
-	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 
 	"kubesphere.io/devops/pkg/api"
 	"kubesphere.io/devops/pkg/apiserver/query"
@@ -310,7 +308,7 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (devops.DevopsOperat
 
 	if kubernetesClient, err := k8s.NewKubernetesClientWithToken(token, h.k8sClient.Config().Host); err != nil {
 		return nil, err
-	} else if kubernetesClient != nil {
+	} else {
 		informerFactory := devopsinformers.NewInformerFactories(kubernetesClient.Kubernetes(),
 			kubernetesClient.KubeSphere(),
 			kubernetesClient.ApiExtensions())
@@ -320,8 +318,6 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (devops.DevopsOperat
 			informerFactory.KubeSphereSharedInformerFactory(),
 			informerFactory.KubernetesSharedInformerFactory()), nil
 	}
-	// when kubernetesClient == nil, we will complain unauthorized error
-	return nil, restful.NewError(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 }
 
 func (h *devopsHandler) ListCredential(request *restful.Request, response *restful.Response) {

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/constants"
+	"net/http"
 
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 
@@ -309,7 +310,7 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (devops.DevopsOperat
 
 	if kubernetesClient, err := k8s.NewKubernetesClientWithToken(token, h.k8sClient.Config().Host); err != nil {
 		return nil, err
-	} else {
+	} else if kubernetesClient != nil {
 		informerFactory := devopsinformers.NewInformerFactories(kubernetesClient.Kubernetes(),
 			kubernetesClient.KubeSphere(),
 			kubernetesClient.ApiExtensions())
@@ -319,6 +320,8 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (devops.DevopsOperat
 			informerFactory.KubeSphereSharedInformerFactory(),
 			informerFactory.KubernetesSharedInformerFactory()), nil
 	}
+	// when kubernetesClient == nil, we will complain unauthorized error
+	return nil, restful.NewError(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 }
 
 func (h *devopsHandler) ListCredential(request *restful.Request, response *restful.Response) {


### PR DESCRIPTION
When we request pipeline list api without token as follow.  Http status `Unauthorized` is supposed to be returned, but `Empty reply from server`:

```bash
➜  ~ curl -v http://localhost:9090/kapis/devops.kubesphere.io/v1alpha3/devops/testblpsz/pipelines
*   Trying ::1:9090...
* Connected to localhost (::1) port 9090 (#0)
> GET /kapis/devops.kubesphere.io/v1alpha3/devops/testblpsz/pipelines HTTP/1.1
> Host: localhost:9090
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Empty reply from server
* Closing connection 0
curl: (52) Empty reply from server
```

This PR tries to fix the following error:

```go
2021/07/06 14:51:45 http: panic serving [::1]:51314: runtime error: invalid memory address or nil pointer dereference
goroutine 649 [running]:
net/http.(*conn).serve.func1(0xc000e5e5a0)
        /usr/lib/go/src/net/http/server.go:1824 +0x14c
panic(0x23e1b80, 0x34ee740)
        /usr/lib/go/src/runtime/panic.go:971 +0x4c7
kubesphere.io/devops/pkg/kapis/devops/v1alpha3.(*devopsHandler).getDevOps(0xc0006dbb60, 0xc000fdaf60, 0x0, 0x0, 0x0, 0x0)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/kapis/devops/v1alpha3/handler.go:312 +0x247
kubesphere.io/devops/pkg/kapis/devops/v1alpha3.(*devopsHandler).ListPipeline(0xc0006dbb60, 0xc000fdaf60, 0xc000a52af0)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/kapis/devops/v1alpha3/handler.go:194 +0xed
github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc000fdb080, 0xc000fdaf60, 0xc000a52af0)
        /home/johnniang/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/filter.go:21 +0xdb
kubesphere.io/devops/pkg/apiserver.logRequestAndResponse(0xc000fdaf60, 0xc000a52af0, 0xc000fdb080)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/apiserver/apiserver.go:341 +0x88
github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc000fdb080, 0xc000fdaf60, 0xc000a52af0)
        /home/johnniang/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/filter.go:19 +0xac
github.com/emicklei/go-restful.(*Container).dispatch(0xc000a3cea0, 0x2912248, 0xc001804540, 0xc0009f5d00)
        /home/johnniang/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/container.go:282 +0xf17
net/http.HandlerFunc.ServeHTTP(0xc0009b0060, 0x2912248, 0xc001804540, 0xc0009f5d00)
        /usr/lib/go/src/net/http/server.go:2069 +0x44
net/http.(*ServeMux).ServeHTTP(0xc000a19480, 0x2912248, 0xc001804540, 0xc0009f5d00)
        /usr/lib/go/src/net/http/server.go:2448 +0x1ab
github.com/emicklei/go-restful.(*Container).ServeHTTP(0xc000a3cea0, 0x2912248, 0xc001804540, 0xc0009f5d00)
        /home/johnniang/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/container.go:300 +0x54
kubesphere.io/devops/pkg/apiserver/filters.WithKubeAPIServer.func1(0x2912248, 0xc001804540, 0xc0009f5d00)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/apiserver/filters/kubeapiserver.go:62 +0x31c
net/http.HandlerFunc.ServeHTTP(0xc0006e1980, 0x2912248, 0xc001804540, 0xc0009f5d00)
        /usr/lib/go/src/net/http/server.go:2069 +0x44
kubesphere.io/devops/pkg/apiserver/filters.WithAuthentication.func1(0x2912248, 0xc001804540, 0xc0009f5d00)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/apiserver/filters/authentication.go:70 +0x615
net/http.HandlerFunc.ServeHTTP(0xc0006e1a40, 0x2912248, 0xc001804540, 0xc0009f5c00)
        /usr/lib/go/src/net/http/server.go:2069 +0x44
kubesphere.io/devops/pkg/apiserver/filters.WithRequestInfo.func1(0x2912248, 0xc001804540, 0xc0009f5c00)
        /home/johnniang/workspace/kubesphere/ks-devops/pkg/apiserver/filters/requestinfo.go:73 +0x6ad
net/http.HandlerFunc.ServeHTTP(0xc0008abec0, 0x2912248, 0xc001804540, 0xc0009f5700)
        /usr/lib/go/src/net/http/server.go:2069 +0x44
net/http.serverHandler.ServeHTTP(0xc0001f8380, 0x2912248, 0xc001804540, 0xc0009f5700)
        /usr/lib/go/src/net/http/server.go:2887 +0x22b
net/http.(*conn).serve(0xc000e5e5a0, 0x2914518, 0xc000bed980)
        /usr/lib/go/src/net/http/server.go:1952 +0x1c25
created by net/http.(*Server).Serve
        /usr/lib/go/src/net/http/server.go:3013 +0x96e

```

After fixing:

```go
E0706 14:45:17.560897  668802 utils.go:76] /home/johnniang/workspace/kubesphere/ks-devops/pkg/kapis/devops/v1alpha3/handler.go:209 [ServiceError:401] Unauthorized
```